### PR TITLE
Use do instead of begin in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Here is an example:
 using Persist
 
 # Start a calculation in the background
-job = persist("hello", ProcessManager) begin
+job = persist("hello", ProcessManager) do
     sleep(10)   # Simulate a long-running task
     println("Hello, World!")   # Produce some output
     return [42]   # Return a value


### PR DESCRIPTION
It solves: `ERROR: syntax: extra token "begin" after end of expression`
